### PR TITLE
fix: MacOS shows unsupported architecture

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ detect_platform() {
 
   case $ARCH in
   x86_64) ARCH="amd64" ;;
-  aarch64) ARCH="arm64" ;;
+  aarch64 | arm64) ARCH="arm64" ;;
   *)
     echo "Unsupported architecture: $ARCH"
     exit 1


### PR DESCRIPTION
`uname -a` on MacOS returns

```
Darwin Shivams-Laptop.local 23.2.0 Darwin Kernel Version 23.2.0: Wed Nov 15 21:53:18 PST 2023; root:xnu-10002.61.3~2/RELEASE_ARM64_T6000 arm64
```

The architecture is `arm64`, which is returned as is, when `uname -m` is run. The subsequent check does not handle this and the script returns `Unsupported architecture`. This PR fixes it.

Also an enhancement can be made to automatically detect the latest version

```bash
args=("$@")
custom_version=${args[0]}

# Function to detect latest GitHub release
get_latest_release() {
  local repo=$1
  curl -s "https://api.github.com/repos/${repo}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
}

if [ -z "$custom_version" ]; then
  custom_version=$(get_latest_release "coollabsio/coolify-cli")
fi
``` 

Let me know if you want me to update the PR

P.S. I hope you enjoyed writing Go, I'm using your script as a reference for [`slick-deploy`](https://github.com/scmmishra/slick-deploy). Thanks for the wonderful work